### PR TITLE
Support new method `BlobContainer#move()`

### DIFF
--- a/src/main/java/org/elasticsearch/cloud/azure/AzureStorageService.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/AzureStorageService.java
@@ -59,4 +59,6 @@ public interface AzureStorageService {
     OutputStream getOutputStream(String container, String blob) throws URISyntaxException, StorageException;
 
     ImmutableMap<String,BlobMetaData> listBlobsByPrefix(String container, String keyPath, String prefix) throws URISyntaxException, StorageException, ServiceException;
+
+    void moveBlob(String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException;
 }

--- a/src/main/java/org/elasticsearch/cloud/azure/AzureStorageServiceImpl.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/AzureStorageServiceImpl.java
@@ -215,6 +215,19 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
     }
 
     @Override
+    public void moveBlob(String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException {
+        logger.debug("moveBlob container [{}], sourceBlob [{}], targetBlob [{}]", container, sourceBlob, targetBlob);
+        CloudBlobContainer blob_container = client.getContainerReference(container);
+        CloudBlockBlob blobSource = blob_container.getBlockBlobReference(sourceBlob);
+        if (blobSource.exists()) {
+            CloudBlockBlob blobTarget = blob_container.getBlockBlobReference(targetBlob);
+            blobTarget.copyFromBlob(blobSource);
+            blobSource.delete();
+            logger.debug("moveBlob container [{}], sourceBlob [{}], targetBlob [{}] -> done", container, sourceBlob, targetBlob);
+        }
+    }
+
+    @Override
     protected void doStart() throws ElasticsearchException {
         logger.debug("starting azure storage client instance");
     }

--- a/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
 import org.elasticsearch.common.collect.ImmutableMap;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.repositories.RepositoryException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -45,8 +46,9 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     protected final AzureBlobStore blobStore;
 
     protected final String keyPath;
+    protected final String repositoryName;
 
-    public AzureBlobContainer(BlobPath path, AzureBlobStore blobStore) {
+    public AzureBlobContainer(String repositoryName, BlobPath path, AzureBlobStore blobStore) {
         super(path);
         this.blobStore = blobStore;
         String keyPath = path.buildAsString("/");
@@ -54,6 +56,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
             keyPath = keyPath + "/";
         }
         this.keyPath = keyPath;
+        this.repositoryName = repositoryName;
     }
 
     @Override
@@ -89,6 +92,8 @@ public class AzureBlobContainer extends AbstractBlobContainer {
             throw new IOException(e);
         } catch (URISyntaxException e) {
             throw new IOException(e);
+        } catch (IllegalArgumentException e) {
+            throw new RepositoryException(repositoryName, e.getMessage());
         }
     }
 

--- a/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -119,6 +119,24 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     }
 
     @Override
+    public void move(String sourceBlobName, String targetBlobName) throws IOException {
+        try {
+            String source = keyPath + sourceBlobName;
+            String target = keyPath + targetBlobName;
+
+            logger.debug("moving blob [{}] to [{}] in container {{}}", source, target, blobStore.container());
+
+            blobStore.client().moveBlob(blobStore.container(), source, target);
+        } catch (URISyntaxException e) {
+            logger.warn("can not move blob [{}] to [{}] in container {{}}: {}", sourceBlobName, targetBlobName, blobStore.container(), e.getMessage());
+            throw new IOException(e);
+        } catch (StorageException e) {
+            logger.warn("can not move blob [{}] to [{}] in container {{}}: {}", sourceBlobName, targetBlobName, blobStore.container(), e.getMessage());
+            throw new IOException(e);
+        }
+    }
+
+    @Override
     public ImmutableMap<String, BlobMetaData> listBlobs() throws IOException {
         return listBlobsByPrefix(null);
     }

--- a/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
+++ b/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
@@ -100,6 +100,17 @@ public class AzureStorageServiceMock extends AbstractLifecycleComponent<AzureSto
     }
 
     @Override
+    public void moveBlob(String container, String sourceBlob, String targetBlob) throws URISyntaxException, StorageException {
+        for (String blobName : blobs.keySet()) {
+            if (endsWithIgnoreCase(blobName, sourceBlob)) {
+                ByteArrayOutputStream outputStream = blobs.get(blobName);
+                blobs.put(blobName.replace(sourceBlob, targetBlob), outputStream);
+                blobs.remove(blobName);
+            }
+        }
+    }
+
+    @Override
     protected void doStart() throws ElasticsearchException {
     }
 
@@ -131,6 +142,29 @@ public class AzureStorageServiceMock extends AbstractLifecycleComponent<AzureSto
         }
         String lcStr = str.substring(0, prefix.length()).toLowerCase(Locale.ROOT);
         String lcPrefix = prefix.toLowerCase(Locale.ROOT);
+        return lcStr.equals(lcPrefix);
+    }
+
+    /**
+     * Test if the given String ends with the specified suffix,
+     * ignoring upper/lower case.
+     *
+     * @param str    the String to check
+     * @param suffix the suffix to look for
+     * @see java.lang.String#startsWith
+     */
+    public static boolean endsWithIgnoreCase(String str, String suffix) {
+        if (str == null || suffix == null) {
+            return false;
+        }
+        if (str.endsWith(suffix)) {
+            return true;
+        }
+        if (str.length() < suffix.length()) {
+            return false;
+        }
+        String lcStr = str.substring(0, suffix.length()).toLowerCase(Locale.ROOT);
+        String lcPrefix = suffix.toLowerCase(Locale.ROOT);
         return lcStr.equals(lcPrefix);
     }
 }


### PR DESCRIPTION
This has been added in elasticsearch 2.0.0. See elasticsearch/elasticsearch#8782

Wondering if this PR should be split in two parts:

* one that clean the code and which is portable to 1.4, 1.x and master
* one that simply add move() method for master branch

@imotov WDYT?

Closes #49.