### PR TITLE
Create container when snapshot starts

### DIFF
--- a/src/main/java/org/elasticsearch/cloud/azure/AzureComputeServiceImpl.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/AzureComputeServiceImpl.java
@@ -83,7 +83,7 @@ public class AzureComputeServiceImpl extends AbstractLifecycleComponent<AzureCom
         // Check that we have all needed properties
         try {
             socketFactory = getSocketFactory(keystore, password);
-            if (logger.isTraceEnabled()) logger.trace("creating new Azure client for [{}], [{}], [{}], [{}]",
+            if (logger.isTraceEnabled()) logger.trace("creating new Azure client for [{}], [{}], [{}]",
                     subscription_id, service_name, port_name);
         } catch (Exception e) {
             // Can not start Azure Client

--- a/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -21,6 +21,7 @@ package org.elasticsearch.cloud.azure.blobstore;
 
 import com.microsoft.windowsazure.services.core.ServiceException;
 import com.microsoft.windowsazure.services.core.storage.StorageException;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -28,6 +29,7 @@ import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
 import org.elasticsearch.common.collect.ImmutableMap;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
+import org.elasticsearch.repositories.RepositoryException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -45,8 +47,9 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     protected final AzureBlobStore blobStore;
 
     protected final String keyPath;
+    protected final String repositoryName;
 
-    public AzureBlobContainer(BlobPath path, AzureBlobStore blobStore) {
+    public AzureBlobContainer(String repositoryName, BlobPath path, AzureBlobStore blobStore) {
         super(path);
         this.blobStore = blobStore;
         String keyPath = path.buildAsString("/");
@@ -54,6 +57,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
             keyPath = keyPath + "/";
         }
         this.keyPath = keyPath;
+        this.repositoryName = repositoryName;
     }
 
     @Override
@@ -91,6 +95,8 @@ public class AzureBlobContainer extends AbstractBlobContainer {
             throw new IOException(e);
         } catch (URISyntaxException e) {
             throw new IOException(e);
+        } catch (IllegalArgumentException e) {
+            throw new RepositoryException(repositoryName, e.getMessage());
         }
     }
 
@@ -122,6 +128,11 @@ public class AzureBlobContainer extends AbstractBlobContainer {
             logger.warn("can not access [{}] in container {{}}: {}", prefix, blobStore.container(), e.getMessage());
             throw new IOException(e);
         }
+    }
+
+    @Override
+    public void move(String sourceBlobName, String targetBlobName) throws IOException {
+        throw new ElasticsearchIllegalArgumentException("move() is not implemented yet");
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -22,15 +22,19 @@ package org.elasticsearch.repositories.azure;
 import com.microsoft.windowsazure.services.core.storage.StorageException;
 import org.elasticsearch.cloud.azure.AzureStorageService;
 import org.elasticsearch.cloud.azure.blobstore.AzureBlobStore;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.collect.ImmutableList;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.snapshots.IndexShardRepository;
 import org.elasticsearch.repositories.RepositoryName;
 import org.elasticsearch.repositories.RepositorySettings;
+import org.elasticsearch.repositories.RepositoryVerificationException;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 
 import java.io.IOException;
@@ -60,23 +64,16 @@ public class AzureRepository extends BlobStoreRepository {
 
     private boolean compress;
 
-    /**
-     * Constructs new shared file system repository
-     *
-     * @param name                 repository name
-     * @param repositorySettings   repository settings
-     * @param indexShardRepository index shard repository
-     * @param azureStorageService  Azure Storage service
-     * @throws java.io.IOException
-     */
     @Inject
-    public AzureRepository(RepositoryName name, RepositorySettings repositorySettings, IndexShardRepository indexShardRepository, AzureStorageService azureStorageService) throws IOException, URISyntaxException, StorageException {
+    public AzureRepository(RepositoryName name, RepositorySettings repositorySettings,
+                           IndexShardRepository indexShardRepository,
+                           AzureBlobStore azureBlobStore) throws IOException, URISyntaxException, StorageException {
         super(name.getName(), repositorySettings, indexShardRepository);
 
         String container = repositorySettings.settings().get(AzureStorageService.Fields.CONTAINER,
                 componentSettings.get(AzureStorageService.Fields.CONTAINER, CONTAINER_DEFAULT));
 
-        this.blobStore = new AzureBlobStore(settings, azureStorageService, container);
+        this.blobStore = azureBlobStore;
         this.chunkSize = repositorySettings.settings().getAsBytesSize(AzureStorageService.Fields.CHUNK_SIZE,
                 componentSettings.getAsBytesSize(AzureStorageService.Fields.CHUNK_SIZE, new ByteSizeValue(64, ByteSizeUnit.MB)));
 
@@ -133,5 +130,33 @@ public class AzureRepository extends BlobStoreRepository {
         return chunkSize;
     }
 
+    @Override
+    public void initializeSnapshot(SnapshotId snapshotId, ImmutableList<String> indices, MetaData metaData) {
+        try {
+            if (!blobStore.client().doesContainerExist(blobStore.container())) {
+                blobStore.client().createContainer(blobStore.container());
+            }
+            super.initializeSnapshot(snapshotId, indices, metaData);
+        } catch (StorageException e) {
+            logger.warn("can not initialize container [{}]", blobStore.container());
+        } catch (URISyntaxException e) {
+            logger.warn("can not initialize container [{}]", blobStore.container());
+        }
+    }
 
+    @Override
+    public String startVerification() {
+        try {
+            if (!blobStore.client().doesContainerExist(blobStore.container())) {
+                blobStore.client().createContainer(blobStore.container());
+            }
+            return super.startVerification();
+        } catch (StorageException e) {
+            logger.warn("can not initialize container [{}]", blobStore.container());
+            throw new RepositoryVerificationException(repositoryName, "can not initialize container " + blobStore.container(), e);
+        } catch (URISyntaxException e) {
+            logger.warn("can not initialize container [{}]", blobStore.container());
+            throw new RepositoryVerificationException(repositoryName, "can not initialize container " + blobStore.container(), e);
+        }
+    }
 }


### PR DESCRIPTION
For now, Azure container is created when you create the repository.
It could happen that you manually remove the container using Azure CLI or Azure Console so when you try then to create a new Snapshot it fails.

This commit creates the container if needed when the repository is created or when a snapshot operation is started.

Based on discussion in #53,