### PR TITLE
Failure when creating a container should raise an exception

### DIFF
--- a/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
 import org.elasticsearch.common.collect.ImmutableMap;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.repositories.RepositoryException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -45,8 +46,9 @@ public class AzureBlobContainer extends AbstractBlobContainer {
     protected final AzureBlobStore blobStore;
 
     protected final String keyPath;
+    protected final String repositoryName;
 
-    public AzureBlobContainer(BlobPath path, AzureBlobStore blobStore) {
+    public AzureBlobContainer(String repositoryName, BlobPath path, AzureBlobStore blobStore) {
         super(path);
         this.blobStore = blobStore;
         String keyPath = path.buildAsString("/");
@@ -54,6 +56,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
             keyPath = keyPath + "/";
         }
         this.keyPath = keyPath;
+        this.repositoryName = repositoryName;
     }
 
     @Override
@@ -89,6 +92,8 @@ public class AzureBlobContainer extends AbstractBlobContainer {
             throw new IOException(e);
         } catch (URISyntaxException e) {
             throw new IOException(e);
+        } catch (IllegalArgumentException e) {
+            throw new RepositoryException(repositoryName, e.getMessage());
         }
     }
 


### PR DESCRIPTION
When you remove a container from Azure console, even if Azure told you that it has been done, it appears to be an asynchronous deletion so you can hit error like `can not initialize container [elasticsearch-snapshots]: [The specified container is being deleted. Try operation later.]` but this error does not fail the repository creation...

Related to #54.