### PR TITLE
Rename settings for repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,17 @@ azure vm delete myesnode1
 Azure Repository
 ================
 
-To enable Azure repositories, you have first to set your azure storage settings:
+To enable Azure repositories, you have first to set your azure storage settings in `elasticsearch.yml` file:
+
+```
+cloud:
+    azure:
+        storage:
+            account: your_azure_storage_account
+            key: your_azure_storage_key
+```
+
+For information, in previous version of the azure plugin, settings were:
 
 ```
 cloud:
@@ -409,11 +419,12 @@ Testing
 =======
 
 Integrations tests in this plugin require working Azure configuration and therefore disabled by default.
-To enable tests prepare a config file elasticsearch.yml with the following content:
+To enable tests prepare a config file `elasticsearch.yml` with the following content:
 
 ```
 cloud:
   azure:
+    storage:
       account: "YOUR-AZURE-STORAGE-NAME"
       key: "YOUR-AZURE-STORAGE-KEY"
 ```

--- a/src/main/java/org/elasticsearch/cloud/azure/AzureModule.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/AzureModule.java
@@ -20,6 +20,10 @@
 package org.elasticsearch.cloud.azure;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.cloud.azure.AzureComputeService;
+import org.elasticsearch.cloud.azure.AzureComputeServiceImpl;
+import org.elasticsearch.cloud.azure.storage.AzureStorageService;
+import org.elasticsearch.cloud.azure.storage.AzureStorageServiceImpl;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Inject;
@@ -39,7 +43,7 @@ import org.elasticsearch.discovery.azure.AzureDiscovery;
  * </ul>
  *
  * @see org.elasticsearch.cloud.azure.AzureComputeServiceImpl
- * @see org.elasticsearch.cloud.azure.AzureStorageServiceImpl
+ * @see org.elasticsearch.cloud.azure.storage.AzureStorageServiceImpl
  */
 public class AzureModule extends AbstractModule {
     protected final ESLogger logger;
@@ -121,9 +125,11 @@ public class AzureModule extends AbstractModule {
             return false;
         }
 
-        if (isPropertyMissing(settings, "cloud.azure." + AzureStorageService.Fields.ACCOUNT, null) ||
-                isPropertyMissing(settings, "cloud.azure." + AzureStorageService.Fields.KEY, null)) {
-            logger.trace("azure repository is not set using {} and {} properties",
+        if ((isPropertyMissing(settings, "cloud.azure.storage." + AzureStorageService.Fields.ACCOUNT, null) ||
+                isPropertyMissing(settings, "cloud.azure.storage." + AzureStorageService.Fields.KEY, null)) &&
+                (isPropertyMissing(settings, "cloud.azure." + AzureStorageService.Fields.ACCOUNT_DEPRECATED, null) ||
+                isPropertyMissing(settings, "cloud.azure." + AzureStorageService.Fields.KEY_DEPRECATED, null))) {
+            logger.trace("azure repository is not set [using cloud.azure.storage.{}] and [cloud.azure.storage.{}] properties",
                     AzureStorageService.Fields.ACCOUNT,
                     AzureStorageService.Fields.KEY);
             return false;
@@ -133,6 +139,17 @@ public class AzureModule extends AbstractModule {
 
         return true;
    }
+
+    /**
+     * Check if we are using any deprecated settings
+     */
+    public static void checkDeprecatedSettings(Settings settings, String oldParameter, String newParameter, ESLogger logger) {
+        if (!isPropertyMissing(settings, oldParameter, null)) {
+            logger.warn("using deprecated [{}]. Please change it to [{}] property.",
+                    oldParameter,
+                    newParameter);
+        }
+    }
 
     public static boolean isPropertyMissing(Settings settings, String name, ESLogger logger) throws ElasticsearchException {
         if (!Strings.hasText(settings.get(name))) {

--- a/src/main/java/org/elasticsearch/cloud/azure/AzureSettingsFilter.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/AzureSettingsFilter.java
@@ -19,11 +19,12 @@
 
 package org.elasticsearch.cloud.azure;
 
+import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.SettingsFilter;
 
 /**
- * Filtering cloud.azure.* and repositories.azure.* settings
+ * Filtering cloud.azure.* settings
  */
 public class AzureSettingsFilter implements SettingsFilter.Filter {
 
@@ -35,10 +36,13 @@ public class AzureSettingsFilter implements SettingsFilter.Filter {
         settings.remove("cloud.azure.subscription_id");
         settings.remove("cloud.azure.service_name");
 
-        // Repositories settings
-        settings.remove("repositories.azure.account");
-        settings.remove("repositories.azure.key");
-        settings.remove("repositories.azure.container");
-        settings.remove("repositories.azure.base_path");
+        // Cloud storage API settings
+        settings.remove("cloud.azure.storage." + AzureStorageService.Fields.ACCOUNT);
+        settings.remove("cloud.azure.storage." + AzureStorageService.Fields.KEY);
+
+        // Deprecated Cloud storage API settings
+        // TODO Remove in 3.0.0
+        settings.remove("cloud.azure." + AzureStorageService.Fields.ACCOUNT_DEPRECATED);
+        settings.remove("cloud.azure." + AzureStorageService.Fields.KEY_DEPRECATED);
     }
 }

--- a/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobStore.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobStore.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.cloud.azure.blobstore;
 
 import com.microsoft.azure.storage.StorageException;
-import org.elasticsearch.cloud.azure.AzureStorageService;
+import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;

--- a/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.cloud.azure;
+package org.elasticsearch.cloud.azure.storage;
 
 import com.microsoft.azure.storage.StorageException;
 import org.elasticsearch.common.blobstore.BlobMetaData;
@@ -29,12 +29,16 @@ import java.net.URISyntaxException;
 
 /**
  * Azure Storage Service interface
- * @see org.elasticsearch.cloud.azure.AzureStorageServiceImpl for Azure REST API implementation
+ * @see AzureStorageServiceImpl for Azure REST API implementation
  */
 public interface AzureStorageService {
     static public final class Fields {
-        public static final String ACCOUNT = "storage_account";
-        public static final String KEY = "storage_key";
+        @Deprecated
+        public static final String ACCOUNT_DEPRECATED = "storage_account";
+        @Deprecated
+        public static final String KEY_DEPRECATED = "storage_key";
+        public static final String ACCOUNT = "account";
+        public static final String KEY = "key";
         public static final String CONTAINER = "container";
         public static final String BASE_PATH = "base_path";
         public static final String CHUNK_SIZE = "chunk_size";

--- a/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceImpl.java
@@ -17,12 +17,13 @@
  * under the License.
  */
 
-package org.elasticsearch.cloud.azure;
+package org.elasticsearch.cloud.azure.storage;
 
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.*;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.cloud.azure.AzureSettingsFilter;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.support.PlainBlobMetaData;
 import org.elasticsearch.common.collect.ImmutableMap;
@@ -54,9 +55,9 @@ public class AzureStorageServiceImpl extends AbstractLifecycleComponent<AzureSto
         super(settings);
         settingsFilter.addFilter(new AzureSettingsFilter());
 
-        // We try to load storage API settings from `cloud.azure.`
-        account = settings.get("cloud.azure." + Fields.ACCOUNT);
-        key = settings.get("cloud.azure." + Fields.KEY);
+        // We try to load storage API settings from `repositories.azure.`
+        account = componentSettings.get(Fields.ACCOUNT, settings.get("cloud.azure." + Fields.ACCOUNT_DEPRECATED));
+        key = componentSettings.get(Fields.KEY, settings.get("cloud.azure." + Fields.KEY_DEPRECATED));
         blob = "http://" + account + ".blob.core.windows.net/";
 
         try {

--- a/src/main/java/org/elasticsearch/plugin/cloud/azure/CloudAzurePlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/cloud/azure/CloudAzurePlugin.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.plugin.cloud.azure;
 
 import org.elasticsearch.cloud.azure.AzureModule;
+import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.common.collect.Lists;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.logging.ESLogger;
@@ -31,6 +32,9 @@ import org.elasticsearch.repositories.azure.AzureRepository;
 import org.elasticsearch.repositories.azure.AzureRepositoryModule;
 
 import java.util.Collection;
+
+import static org.elasticsearch.cloud.azure.AzureModule.checkDeprecatedSettings;
+import static org.elasticsearch.cloud.azure.AzureModule.isSnapshotReady;
 
 /**
  *
@@ -65,9 +69,18 @@ public class CloudAzurePlugin extends AbstractPlugin {
 
     @Override
     public void processModule(Module module) {
-        if (AzureModule.isSnapshotReady(settings, logger)
+        if (isSnapshotReady(settings, logger)
                 && module instanceof RepositoriesModule) {
+            // Check if we have any deprecated setting
+            checkDeprecated();
             ((RepositoriesModule)module).registerRepository(AzureRepository.TYPE, AzureRepositoryModule.class);
         }
+    }
+
+    private void checkDeprecated() {
+        checkDeprecatedSettings(settings, "cloud.azure." + AzureStorageService.Fields.ACCOUNT_DEPRECATED,
+                "cloud.azure.storage." + AzureStorageService.Fields.ACCOUNT, logger);
+        checkDeprecatedSettings(settings, "cloud.azure." + AzureStorageService.Fields.KEY_DEPRECATED,
+                "cloud.azure.storage." + AzureStorageService.Fields.KEY, logger);
     }
 }

--- a/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.repositories.azure;
 
 import com.microsoft.azure.storage.StorageException;
-import org.elasticsearch.cloud.azure.AzureStorageService;
+import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.cloud.azure.blobstore.AzureBlobStore;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.metadata.SnapshotId;

--- a/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
+++ b/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceMock.java
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-package org.elasticsearch.repositories.azure;
+package org.elasticsearch.cloud.azure.storage;
 
 import com.microsoft.azure.storage.StorageException;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.cloud.azure.AzureStorageService;
 import org.elasticsearch.common.blobstore.BlobMetaData;
 import org.elasticsearch.common.blobstore.support.PlainBlobMetaData;
 import org.elasticsearch.common.collect.ImmutableMap;

--- a/src/test/java/org/elasticsearch/repositories/azure/AbstractAzureRepositoryServiceTest.java
+++ b/src/test/java/org/elasticsearch/repositories/azure/AbstractAzureRepositoryServiceTest.java
@@ -21,7 +21,7 @@ package org.elasticsearch.repositories.azure;
 
 import com.microsoft.azure.storage.StorageException;
 import org.elasticsearch.cloud.azure.AbstractAzureTest;
-import org.elasticsearch.cloud.azure.AzureStorageService;
+import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -66,10 +66,17 @@ public abstract class AbstractAzureRepositoryServiceTest extends AbstractAzureTe
     protected Settings nodeSettings(int nodeOrdinal) {
         ImmutableSettings.Builder builder = ImmutableSettings.settingsBuilder()
                 .put("plugins." + PluginsService.LOAD_PLUGIN_FROM_CLASSPATH, true)
-                .put("cloud.azure." + AzureStorageService.Fields.ACCOUNT, "mock_azure_account")
-                .put("cloud.azure." + AzureStorageService.Fields.KEY, "mock_azure_key")
                 .put("repositories.azure.api.impl", mock)
                 .put("repositories.azure.container", "snapshots");
+
+        // We use sometime deprecated settings in tests
+        if (rarely()) {
+            builder.put("cloud.azure." + AzureStorageService.Fields.ACCOUNT_DEPRECATED, "mock_azure_account")
+                    .put("cloud.azure." + AzureStorageService.Fields.KEY_DEPRECATED, "mock_azure_key");
+        } else {
+            builder.put("cloud.azure.storage." + AzureStorageService.Fields.ACCOUNT, "mock_azure_account")
+                    .put("cloud.azure.storage." + AzureStorageService.Fields.KEY, "mock_azure_key");
+        }
 
         return builder.build();
     }

--- a/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotRestoreITest.java
+++ b/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotRestoreITest.java
@@ -27,7 +27,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotR
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.cloud.azure.AbstractAzureTest;
-import org.elasticsearch.cloud.azure.AzureStorageService;
+import org.elasticsearch.cloud.azure.storage.AzureStorageService;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.base.Predicate;
@@ -69,6 +69,14 @@ public class AzureSnapshotRestoreITest extends AbstractAzureTest {
     private String getContainerName() {
         String testName = "it-".concat(Strings.toUnderscoreCase(getTestName()).replaceAll("_", "-"));
         return testName.contains(" ") ? Strings.split(testName, " ")[0] : testName;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.builder().put(super.nodeSettings(nodeOrdinal))
+                // In snapshot tests, we explicitly disable cloud discovery
+                .put("discovery.type", "local")
+                .build();
     }
 
     @Override

--- a/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotRestoreTest.java
+++ b/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotRestoreTest.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResp
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cloud.azure.storage.AzureStorageServiceMock;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.snapshots.SnapshotState;


### PR DESCRIPTION
Storage and Management settings are not related in Azure API.
We were using the following convention for storage specific settings:

```yml
cloud:
    azure:
        storage_account: your_azure_storage_account
        storage_key: your_azure_storage_key
```

A better naming (and Java packaging) would be by moving `storage` settings in their own package
`cloud.azure.storage`:

```yml
cloud:
    azure:
        storage:
            account: your_azure_storage_account
            key: your_azure_storage_key
```

Note that we can still read deprecated settings but it will print a `WARN` with an advice to make sure users don't forget to move.