### PR TITLE
Simplify  setting index.store.type with smb_simple_fs and smb_mmap_fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,24 +432,26 @@ When using a shared file system based on the SMB protocol (like Azure File Servi
 
 The Azure Cloud plugin provides two storage types optimized for SMB:
 
-- `org.elasticsearch.index.store.fs.SmbMmapFsIndexStoreModule`: a SMB specific implementation of the default [mmap fs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules-store.html#mmapfs)
-- `org.elasticsearch.index.store.fs.SmbSimpleFsIndexStoreModule`: a SMB specific implementation of the default [simple fs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules-store.html#simplefs)
+- `smb_mmap_fs`: a SMB specific implementation of the default [mmap fs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules-store.html#mmapfs)
+- `smb_simple_fs`: a SMB specific implementation of the default [simple fs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/index-modules-store.html#simplefs)
 
-To use one of these specific storage types, you need to install the Azure Cloud plugin and restart the node. Then configure Elasticsearch to set
-the storage type you want.
+To use one of these specific storage types, you need to install the Azure Cloud plugin and restart the node.
+Then configure Elasticsearch to set the storage type you want.
 
-This can be configured for all indices by adding this to the config/elasticsearch.yml file:
-```
-index.store.type: org.elasticsearch.index.store.fs.SmbSimpleFsIndexStoreModule
+This can be configured for all indices by adding this to the `elasticsearch.yml` file:
+
+```yaml
+index.store.type: smb_simple_fs
 ```
 
 Note that setting will be applied for newly created indices.
 
 It can also be set on a per-index basis at index creation time:
-```
+
+```sh
 curl -XPUT localhost:9200/my_index -d '{
    "settings": {
-       "index.store.type": "org.elasticsearch.index.store.fs.SmbMmapFsIndexStoreModule"
+       "index.store.type": "smb_mmap_fs"
    }
 }'
 ```

--- a/src/main/java/org/elasticsearch/index/store/smbmmapfs/SmbMmapFsDirectoryService.java
+++ b/src/main/java/org/elasticsearch/index/store/smbmmapfs/SmbMmapFsDirectoryService.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.index.store.fs;
+package org.elasticsearch.index.store.smbmmapfs;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockFactory;
@@ -28,6 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.IndexStore;
+import org.elasticsearch.index.store.fs.FsDirectoryService;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/org/elasticsearch/index/store/smbmmapfs/SmbMmapFsIndexStore.java
+++ b/src/main/java/org/elasticsearch/index/store/smbmmapfs/SmbMmapFsIndexStore.java
@@ -17,31 +17,27 @@
  * under the License.
  */
 
-package org.elasticsearch.index.store.fs;
+package org.elasticsearch.index.store.smbmmapfs;
 
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.LockFactory;
-import org.apache.lucene.store.SimpleFSDirectory;
-import org.apache.lucene.store.SmbDirectoryWrapper;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.settings.IndexSettings;
-import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.store.IndexStore;
+import org.elasticsearch.index.store.DirectoryService;
+import org.elasticsearch.index.store.fs.FsIndexStore;
+import org.elasticsearch.indices.store.IndicesStore;
 
-import java.io.File;
-import java.io.IOException;
-
-public class SmbSimpleFsDirectoryService extends FsDirectoryService {
+public class SmbMmapFsIndexStore extends FsIndexStore {
 
     @Inject
-    public SmbSimpleFsDirectoryService(ShardId shardId, @IndexSettings Settings indexSettings, IndexStore indexStore) {
-        super(shardId, indexSettings, indexStore);
+    public SmbMmapFsIndexStore(Index index, @IndexSettings Settings indexSettings, IndexService indexService, IndicesStore indicesStore, NodeEnvironment nodeEnv) {
+        super(index, indexSettings, indexService, indicesStore, nodeEnv);
     }
 
     @Override
-    protected Directory newFSDirectory(File location, LockFactory lockFactory) throws IOException {
-        logger.debug("wrapping SimpleFSDirectory for SMB");
-        return new SmbDirectoryWrapper(new SimpleFSDirectory(location, lockFactory));
+    public Class<? extends DirectoryService> shardDirectory() {
+        return SmbMmapFsDirectoryService.class;
     }
 }

--- a/src/main/java/org/elasticsearch/index/store/smbmmapfs/SmbMmapFsIndexStoreModule.java
+++ b/src/main/java/org/elasticsearch/index/store/smbmmapfs/SmbMmapFsIndexStoreModule.java
@@ -17,15 +17,15 @@
  * under the License.
  */
 
-package org.elasticsearch.index.store.fs;
+package org.elasticsearch.index.store.smbmmapfs;
 
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.index.store.IndexStore;
 
-public class SmbSimpleFsIndexStoreModule extends AbstractModule {
+public class SmbMmapFsIndexStoreModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(IndexStore.class).to(SmbSimpleFsIndexStore.class).asEagerSingleton();
+        bind(IndexStore.class).to(SmbMmapFsIndexStore.class).asEagerSingleton();
     }
 }

--- a/src/main/java/org/elasticsearch/index/store/smbsimplefs/SmbSimpleFsDirectoryService.java
+++ b/src/main/java/org/elasticsearch/index/store/smbsimplefs/SmbSimpleFsDirectoryService.java
@@ -17,26 +17,32 @@
  * under the License.
  */
 
-package org.elasticsearch.index.store.fs;
+package org.elasticsearch.index.store.smbsimplefs;
 
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.LockFactory;
+import org.apache.lucene.store.SimpleFSDirectory;
+import org.apache.lucene.store.SmbDirectoryWrapper;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.settings.IndexSettings;
-import org.elasticsearch.index.store.DirectoryService;
-import org.elasticsearch.indices.store.IndicesStore;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.store.IndexStore;
+import org.elasticsearch.index.store.fs.FsDirectoryService;
 
-public class SmbMmapFsIndexStore extends FsIndexStore {
+import java.io.File;
+import java.io.IOException;
+
+public class SmbSimpleFsDirectoryService extends FsDirectoryService {
 
     @Inject
-    public SmbMmapFsIndexStore(Index index, @IndexSettings Settings indexSettings, IndexService indexService, IndicesStore indicesStore, NodeEnvironment nodeEnv) {
-        super(index, indexSettings, indexService, indicesStore, nodeEnv);
+    public SmbSimpleFsDirectoryService(ShardId shardId, @IndexSettings Settings indexSettings, IndexStore indexStore) {
+        super(shardId, indexSettings, indexStore);
     }
 
     @Override
-    public Class<? extends DirectoryService> shardDirectory() {
-        return SmbMmapFsDirectoryService.class;
+    protected Directory newFSDirectory(File location, LockFactory lockFactory) throws IOException {
+        logger.debug("wrapping SimpleFSDirectory for SMB");
+        return new SmbDirectoryWrapper(new SimpleFSDirectory(location, lockFactory));
     }
 }

--- a/src/main/java/org/elasticsearch/index/store/smbsimplefs/SmbSimpleFsIndexStore.java
+++ b/src/main/java/org/elasticsearch/index/store/smbsimplefs/SmbSimpleFsIndexStore.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.elasticsearch.index.store.fs;
+package org.elasticsearch.index.store.smbsimplefs;
 
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
@@ -26,6 +26,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.service.IndexService;
 import org.elasticsearch.index.settings.IndexSettings;
 import org.elasticsearch.index.store.DirectoryService;
+import org.elasticsearch.index.store.fs.FsIndexStore;
 import org.elasticsearch.indices.store.IndicesStore;
 
 public class SmbSimpleFsIndexStore extends FsIndexStore {

--- a/src/main/java/org/elasticsearch/index/store/smbsimplefs/SmbSimpleFsIndexStoreModule.java
+++ b/src/main/java/org/elasticsearch/index/store/smbsimplefs/SmbSimpleFsIndexStoreModule.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.store.smbsimplefs;
+
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.index.store.IndexStore;
+
+public class SmbSimpleFsIndexStoreModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(IndexStore.class).to(SmbSimpleFsIndexStore.class).asEagerSingleton();
+    }
+}

--- a/src/test/java/org/elasticsearch/index/store/AbstractAzureFsTest.java
+++ b/src/test/java/org/elasticsearch/index/store/AbstractAzureFsTest.java
@@ -17,15 +17,26 @@
  * under the License.
  */
 
-package org.elasticsearch.index.store.fs;
+package org.elasticsearch.index.store;
 
-import org.elasticsearch.common.inject.AbstractModule;
-import org.elasticsearch.index.store.IndexStore;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
 
-public class SmbMmapFsIndexStoreModule extends AbstractModule {
+import static org.hamcrest.Matchers.is;
 
-    @Override
-    protected void configure() {
-        bind(IndexStore.class).to(SmbMmapFsIndexStore.class).asEagerSingleton();
+abstract public class AbstractAzureFsTest extends ElasticsearchIntegrationTest {
+
+    @Test
+    public void testAzureFs() {
+        // Create an index and index some documents
+        createIndex("test");
+        long nbDocs = randomIntBetween(10, 1000);
+        for (long i = 0; i < nbDocs; i++) {
+            index("test", "doc", "" + i, "foo", "bar");
+        }
+        refresh();
+        SearchResponse response = client().prepareSearch("test").get();
+        assertThat(response.getHits().totalHits(), is(nbDocs));
     }
 }

--- a/src/test/java/org/elasticsearch/index/store/SmbMMapFsTest.java
+++ b/src/test/java/org/elasticsearch/index/store/SmbMMapFsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.store;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+
+
+public class SmbMMapFsTest extends AbstractAzureFsTest {
+
+    @Override
+    public Settings indexSettings() {
+        return ImmutableSettings.builder()
+                .put(super.indexSettings())
+                .put("index.store.type", "smb_mmap_fs")
+                .build();
+    }
+
+}

--- a/src/test/java/org/elasticsearch/index/store/SmbSimpleFsTest.java
+++ b/src/test/java/org/elasticsearch/index/store/SmbSimpleFsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.store;
+
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+
+
+public class SmbSimpleFsTest extends AbstractAzureFsTest {
+    @Override
+    public Settings indexSettings() {
+        return ImmutableSettings.builder()
+                .put(super.indexSettings())
+                .put("index.store.type", "smb_simple_fs")
+                .build();
+    }
+}


### PR DESCRIPTION
This commit changes work done in #60 by using automatic store type discovery which exists in elasticsearch core.

Instead of writing configuration like:

```yaml
index.store.type: org.elasticsearch.index.store.fs.SmbMmapFsIndexStoreModule
index.store.type: org.elasticsearch.index.store.fs.SmbSimpleFsIndexStoreModule
```

We can now use:

```yaml
index.store.type: smb_mmap_fs
index.store.type: smb_simple_fs
```

Note that we move `org.elasticsearch.index.store.fs.SmbMmapFsIndexStoreModule` to  `org.elasticsearch.index.store.smbmmapfs.SmbMmapFsIndexStoreModule` and `org.elasticsearch.index.store.fs.SmbSimpleFsDirectoryService` to `org.elasticsearch.index.store.smbsimplefs.SmbSimpleFsDirectoryService` instead of deprecating the old classes and add new ones.
It means that if users were using a 2.5.2-SNAPSHOT version, they will need to update their settings.